### PR TITLE
[FIX] #OD-1824: Capture magento queue job erros

### DIFF
--- a/connector_magento/exception.py
+++ b/connector_magento/exception.py
@@ -7,3 +7,14 @@ from openerp.addons.connector.exception import RetryableJobError
 
 class OrderImportRuleRetry(RetryableJobError):
     """ The sale order import will be retried later. """
+
+
+class MagentoError(Exception):
+    """Catch Json Error
+    Attributes:
+        json -- Catching the json error explanation of the failed job
+    """
+
+    def __init__(self, msg, json):
+        super().__init__(msg)
+        self.json = json


### PR DESCRIPTION
Capture Magento queue job errors. 
 - Check for response and handle the response body.
 - In case of no response found, raise the error handled by raise_for_status() 